### PR TITLE
Adds quick-and-dirty escaping of spaces in CLIArgs

### DIFF
--- a/Source/CompilationDatabase.mm
+++ b/Source/CompilationDatabase.mm
@@ -116,6 +116,16 @@ static NSArray *EntriesForCompileCRecord(XCDependencyCommandInvocationRecord *re
             *stop = YES;
         }
     }];
+    
+    // quick-and-dirty shell-escaping spaces in filenames.
+    // Should probably also escape other characters.
+    NSMutableArray* escapedCLIArgs = [NSMutableArray arrayWithCapacity:CLIArgs.count];
+    for(NSString* arg in CLIArgs)
+    {
+        NSString* escapedArg = [arg stringByReplacingOccurrencesOfString:@" " withString:@"\\ "];
+        [escapedCLIArgs addObject:escapedArg];
+    }
+    CLIArgs = [escapedCLIArgs copy];
 
     // This is malformed, but be safe.
     if (!fileName) {


### PR DESCRIPTION
This fixes an issue (#2) whereby using file paths with embedded spaces would have invalid "command" entries in the compile database, for files processed thru clang.